### PR TITLE
Draft: fix error when mcp tool doesn't exist

### DIFF
--- a/src/renderer/ChatContext.ts
+++ b/src/renderer/ChatContext.ts
@@ -74,14 +74,14 @@ const getMaxTokens = () => {
   const prompt = chat.prompt as IPrompt | null;
   if (
     prompt?.maxTokens != null &&
-    isValidMaxTokens(prompt?.maxTokens, provider.name, model?.name as string)
+    isValidMaxTokens(prompt?.maxTokens, provider?.name, model?.name as string)
   ) {
     maxTokens = prompt?.maxTokens || (prompt?.maxTokens as number);
   }
   console.log('chat?.maxTokens', chat?.maxTokens);
   if (
     chat?.maxTokens != null &&
-    isValidMaxTokens(chat?.maxTokens, provider.name, model.name as string)
+    isValidMaxTokens(chat?.maxTokens, provider?.name, model?.name as string)
   ) {
     maxTokens = chat?.maxTokens as number;
   }

--- a/src/stores/useProviderStore.ts
+++ b/src/stores/useProviderStore.ts
@@ -295,7 +295,7 @@ const useProviderStore = create<IProviderStore>((set, get) => ({
       models: [],
       disabled: false,
     } as Partial<IChatProviderConfig>;
-    const customProviders = window.electron.store.get('providers');
+    const customProviders = window.electron.store.get('providers') || [];
     const newCustomProviders = (
       [...customProviders, newProvider] as IChatProviderConfig[]
     ).sort(sortByName);


### PR DESCRIPTION
**draft**

try fix #247

hypothesis:
- when a message is sent, the application processes it and may identify MCP tools to call using listTools in mcp.ts
- if mcp client has issues with fetching tools, it throws an error
- error is not caught thus crashing the message request

the fix: if a client fails during listTools, we still return the tools from successful clients, and the message can be sent to the AI model